### PR TITLE
Simplify latest version extraction from packagist json file and removes deprecation message from action output 

### DIFF
--- a/.github/workflows/update_version.yml
+++ b/.github/workflows/update_version.yml
@@ -21,12 +21,14 @@ jobs:
       - name: "Update Dockerfile and action.yml"
         id: fetch_version
         run: |
-          latest=$(curl -s https://packagist.org/packages/phparkitect/phparkitect.json|jq '[.package.versions[]|select(.version|test("^\\d+\\.\\d+\\.\\d+$"))|.version]|max_by(.|[splits("[.]")]|map(tonumber))')
-          latest=$(echo $latest | tr -d '"')
+          latest=$(curl -s https://repo.packagist.org/p2/phparkitect/phparkitect.json | jq -r '.packages[][0] | .version')
+          
           echo "Latest PHPArkitect version is $latest"
-          echo ::set-output name=latest::$latest
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+
           sed -i -re "s/ENV VERSION=.*/ENV VERSION=$latest/" Dockerfile
           cat Dockerfile
+          
           sed -i -re "s/arkitect-github-actions:[0-9.]+/arkitect-github-actions:$latest/" action.yml
           cat action.yml
 


### PR DESCRIPTION
This PR contains two changes 
1. It uses a different packagist endpoint to tech package metadata, documented [here](https://packagist.org/apidoc) in the section "Using the Composer v2 metadata" which requires less manipulation to extract the version number. 
2. Switches to a [new way](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-output-parameter) to define output variables in action steps